### PR TITLE
Custom control label form not unescape HTML

### DIFF
--- a/templates/_partials/form-fields.tpl
+++ b/templates/_partials/form-fields.tpl
@@ -110,7 +110,7 @@
           <input name="{$field.name}" type="checkbox" value="1" id="f-{$field.name}_{$uniqId}"
             class="custom-control-input{if !empty($field.errors)} is-invalid{/if}" {if $field.value} checked="checked"
             {/if}{if $field.required} required{/if}>
-          <label class="custom-control-label" for="f-{$field.name}_{$uniqId}">{$field.label nofilter}</label>
+          <label class="custom-control-label" for="f-{$field.name}_{$uniqId}">{$field.label|unescape:'html' nofilter}</label>
         </div>
       {/block}
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Description?      | The HTML in label of custom control is not unescape
| Type?             | bug fix
| Fixed ticket?     | #172 
