### PR TITLE
Makefile release zip structure fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ build-zip:
 	rm -rf /tmp/falcon/.php-cs-fixer.cache
 	rm -rf /tmp/falcon/.git
 	mv -v /tmp/falcon $(PWD)/falcon
-	zip -r falcon.zip falcon
+	cd falcon && zip -r ../falcon.zip .
 	rm -rf $(PWD)/falcon
 
 create-env:


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Description?      | Fix to falcon release zip file. Release package should contains direct theme files only w/o parent directory.
| Type?             | bug fix
| Fixed ticket?     | NOPE
